### PR TITLE
Add tfoot to native tags list

### DIFF
--- a/src/safe-mdx.tsx
+++ b/src/safe-mdx.tsx
@@ -67,6 +67,7 @@ const nativeTags = [
     'table',
     'tbody',
     'td',
+    'tfoot',
     'th',
     'thead',
     'tr',


### PR DESCRIPTION
Hi :wave:,

When generating some tables we noticed that `tfoot` is not on the native tags list, so the mdx rendering fails. W3schools link: https://www.w3schools.com/TAGS/tag_tfoot.asp

This PR adds it to the native tags list. I couldn't find any tests covering this part, probably since it's not transformed anyway.