### PR TITLE
Make it possible to override default heading tags

### DIFF
--- a/src/safe-mdx.tsx
+++ b/src/safe-mdx.tsx
@@ -230,7 +230,7 @@ export class MdastToJsx {
             case 'heading': {
                 const level = node.depth
 
-                const Tag: any = `h${level}`
+                const Tag = this.c[`h${level}`] ?? `h${level}`
                 return <Tag>{this.mapMdastChildren(node)}</Tag>
             }
             case 'paragraph': {


### PR DESCRIPTION
Fixes #12.

Added optional chaining because nativetags doesn't have `h5` and `h6`. Alternative would be to just add them there.